### PR TITLE
[TT-4363]:  Remove darwin support and add matrix jobs for 1.15

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        gover: [ 1.16, 1.15 ]
+        gover: [ 1.15 ]
+        debver: [ buster, stretch ]
+        include:
+          - debver: stretch
+            tag: 1.15-el7
+          - debver: buster
+            tag: 1.15
 
     runs-on: ubuntu-latest
  
@@ -28,11 +34,12 @@ jobs:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
             
-    - name: Build and push go ${{ matrix.gover }} based image
+    - name: Build and push go ${{ matrix.tag }} based image
       id: docker_build
       uses: docker/build-push-action@v2
       with:
         push: true
-        tags: tykio/golang-cross:${{ matrix.gover }}
+        tags: tykio/golang-cross:${{ matrix.tag }}
         build-args: |
           GO_VERSION=${{ matrix.gover }}
+          DEB_VERSION=${{ matrix.debver }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
       id: docker_build
       uses: docker/build-push-action@v2
       with:
-        push: true
+        push: ${{ github.ref_name == 'master' }}
         tags: tykio/golang-cross:${{ matrix.tag }}
         build-args: |
           GO_VERSION=${{ matrix.gover }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,10 @@
-# Tested for arm64 osx (sdk ver below) amd64 
+# Tested for arm64 osx (sdk ver below) amd64
 ARG GO_VERSION=1.15.15
 
-# OS-X SDK parameters
-ARG OSX_SDK=MacOSX10.15.sdk
-ARG OSX_SDK_SUM=aee7b132a4b10cc26ab9904706412fd0907f5b8b660251e465647d8763f9f009
+ARG DEB_VER=stretch
 
-# osxcross parameters
-ARG OSX_VERSION_MIN=10.12
-ARG OSX_CROSS_COMMIT=c2ad5e859d12
+FROM golang:${GO_VERSION}-${DEB_VER} AS base
 
-FROM golang:${GO_VERSION}-buster AS base
-
-ENV OSX_CROSS_PATH=/osxcross
-
-FROM base AS osx-sdk
-ARG OSX_SDK
-ARG OSX_SDK_SUM
-
-COPY ${OSX_SDK}.tar.xz "${OSX_CROSS_PATH}/tarballs/${OSX_SDK}.tar.xz"
-RUN echo "${OSX_SDK_SUM}"  "${OSX_CROSS_PATH}/tarballs/${OSX_SDK}.tar.xz" | sha256sum -c -
-
-FROM base AS osx-cross-base
 ARG DEBIAN_FRONTEND=noninteractive
 # Install deps
 RUN set -x; echo "Starting image build for $(grep PRETTY_NAME /etc/os-release)" \
@@ -58,25 +42,6 @@ RUN set -x; echo "Starting image build for $(grep PRETTY_NAME /etc/os-release)" 
 && apt -y autoremove                                   \
 && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-# FIXME: install gcc-multilib
-
-FROM osx-cross-base AS osx-cross
-ARG OSX_CROSS_COMMIT
-WORKDIR "${OSX_CROSS_PATH}"
-# install osxcross:
-RUN git clone https://github.com/tpoechtrager/osxcross.git . \
- && git checkout -q "${OSX_CROSS_COMMIT}" \
- && rm -rf ./.git
-COPY --from=osx-sdk "${OSX_CROSS_PATH}/." "${OSX_CROSS_PATH}/"
-ARG OSX_VERSION_MIN
-RUN UNATTENDED=yes OSX_VERSION_MIN=${OSX_VERSION_MIN} ./build.sh
-
-FROM osx-cross-base AS final
-LABEL maintainer="Alok G Singh <alephnull@gmail.com>"
-ARG DEBIAN_FRONTEND=noninteractive
-
-COPY --from=osx-cross "${OSX_CROSS_PATH}/." "${OSX_CROSS_PATH}/"
-ENV PATH=${OSX_CROSS_PATH}/target/bin:$PATH
 
 # install docker cli
 RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - && \
@@ -85,6 +50,10 @@ RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - && \
 
 # Used only when building locally, else the latest goreleaser is installed by GHA
 RUN curl -fsSL https://github.com/goreleaser/goreleaser/releases/latest/download/goreleaser_Linux_x86_64.tar.gz  | tar -C /usr/bin/ -xzf - goreleaser
+
+# Seems like there's an issue with buildx while running docker cli from within the container - the
+# experimental features are not enabled for the  CLI - to mitigate that.
+ENV DOCKER_CLI_EXPERIMENTAL=enabled
 
 COPY unlock-agent.sh /
 COPY daemon.json /etc/docker/daemon.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # Tested for arm64 osx (sdk ver below) amd64
 ARG GO_VERSION=1.15.15
 
-ARG DEB_VER=stretch
+ARG DEB_VERSION=stretch
 
-FROM golang:${GO_VERSION}-${DEB_VER} AS base
+FROM golang:${GO_VERSION}-${DEB_VERSION} AS base
 
 ARG DEBIAN_FRONTEND=noninteractive
 # Install deps


### PR DESCRIPTION
- Remove darwin/amd64 support

- Parameterise the action to build the following go versions.
        - 1.15
        - 1.15-stretch (for el/7 and xenial)