### PR TITLE
Revert "Sign rpms at publish time"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,6 @@ RUN echo "Starting image build for $(grep PRETTY_NAME /etc/os-release)" \
 	unzip                                          \
 	sudo                                           \
 	jq                                             \
-	rpm                                            \
         ruby-dev
 
 # install docker cli

--- a/pc.sh
+++ b/pc.sh
@@ -27,9 +27,6 @@ case $pkg in
 	;;
     *rpm)
 	vers="$RPMVERS"
-	rpm --define "%_gpg_name Team Tyk (package signing) <team@tyk.io>" \
-            --define "%__gpg /usr/bin/gpg" \
-            --addsign $pkg
 	;;
     *)
 	echo "Unknown package, not uploading"


### PR DESCRIPTION
This reverts commit d9b7153fa5cb914f74167e45e4145ea2d3982e54. It seems issue has been fixed now on goreleaser 1.7 and this workaround is not necessary anymore.

<img width="1387" alt="image" src="https://user-images.githubusercontent.com/35462288/160421718-68c6f1c3-c0d9-4e4d-b00e-950625053f6b.png">
