### PR TITLE
Reintroduce rpm signing at publish time.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,10 +36,11 @@ RUN echo "Starting image build for $(grep PRETTY_NAME /etc/os-release)" \
         libxml2-dev                                    \
         lzma-dev                                       \
         openssl                                        \
-	libssl-dev                                     \
-	unzip                                          \
-	sudo                                           \
-	jq                                             \
+        libssl-dev                                     \
+        unzip                                          \
+        sudo                                           \
+        jq                                             \
+        rpm                                            \
         ruby-dev
 
 # install docker cli


### PR DESCRIPTION
We reverted the rpm signing during publish time
to avoid the addsign here failing due to a sign
already present(added by goreleaser when nfpm signing
works fine) - For most cases this should be okay, but
we're reintroducing this in case it fails again like before
on goreleaser's end.

We'll now check if the signature is already present before
invoking the rpm command to add signature.