### PR TITLE
Add Cronjob to rebuld (update) golang-cross images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+  schedule:
+    - cron: '0 0 * * 1' # Run every Monday at 12:00 AM UTC
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
Adds a cronjob trigger every week that will force the update of golang-cross images