### PR TITLE
Add go 1.21 and 1.20

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,23 +16,14 @@ jobs:
       fail-fast: false
       matrix:
         gover:
-          - "1.16"
+          - "1.21"
+          - "1.20"
           - "1.19"
         debver:
-          - bullseye
+          - bookworm
         include:
-          - gover: "1.21"
-            debver: bookworm
-            tag: "1.21"
-          - gover: "1.20"
-            debver: bookworm
-            tag: "1.20"
-          - gover: "1.16"
+          - gover: "1.19"
             debver: bullseye
-            tag: "1.16"
-          - gover: "1.19rc1"
-            debver: stretch
-            tag: "1.19-el7"
 
     runs-on: ubuntu-latest
  

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,12 @@ jobs:
         debver:
           - bullseye
         include:
+          - gover: "1.21"
+            debver: trixie
+            tag: "1.21"
+          - gover: "1.20"
+            debver: bookworm
+            tag: "1.20"
           - gover: "1.16"
             debver: bullseye
             tag: "1.16"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
           - bullseye
         include:
           - gover: "1.21"
-            debver: trixie
+            debver: bookworm
             tag: "1.21"
           - gover: "1.20"
             debver: bookworm


### PR DESCRIPTION
This PR re-adds go 1.20, as well as adds 1.21.

Go 1.20 uses debian bookworm (current debian stable release)
Go 1.21 uses debian bookworm (I wanted to use `trixie`, but no official image)

Both images will be used for testing at the moment, 1.20 may be possibly used in the 5.3 release currently scheduled*(guess-timated?) for january.