### PR TITLE
Add back 1.16 to the list of goversions built

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,12 +23,12 @@ jobs:
           - bullseye
           - bookworm 
         include:
-          - gover: 1.16
+          - gover: "1.16"
             debver: stretch
             tag: 1.16-el7
-          - gover: 1.16
+          - gover: "1.16"
             debver: bullseye
-            tag: 1.16
+            tag: "1.16"
 
 
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,9 +18,18 @@ jobs:
         gover:
           - "1.21"
           - "1.19"
+          - "1.16"
         debver:
           - bullseye
           - bookworm 
+        include:
+          - gover: 1.16
+            debver: stretch
+            tag: 1.16-el7
+          - gover: 1.16
+            debver: bullseye
+            tag: 1.16
+
 
     runs-on: ubuntu-latest
  


### PR DESCRIPTION
1.16 is still used by lts versions, and should have the `tyklabs/packagecloud` binary and be part of the scheduled build.