### PR TITLE
Added go vers 1.22 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         gover:
+          - "1.22"
           - "1.21"
           - "1.19"
         debver:


### PR DESCRIPTION
Added go vers 1.22 to release.yml to facilitate upgrade of tyk-gateway and tyk-dashboard golang version.