### PR TITLE
[TT-15019] Update Gateway and Plugin Compiler to Go 1.24

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         gover:
+          - "1.24"
           - "1.23"
           - "1.22"
           - "1.21"


### PR DESCRIPTION
This PR adds `go-1.24` to `gover` array. We need to do this to build docker images on GW repository. 

Related PR: https://github.com/TykTechnologies/tyk/pull/7265